### PR TITLE
Remove configuration for retired services

### DIFF
--- a/.whitesource
+++ b/.whitesource
@@ -1,8 +1,0 @@
-{
-  "generalSettings": {
-    "shouldScanRepo": true
-  },
-  "checkRunSettings": {
-    "vulnerableCheckRunConclusionLevel": "failure"
-  }
-}


### PR DESCRIPTION
Housekeeping only, no code or dependency touched.

Removed: .whitesource

Greenkeeper shut down and WhiteSource Bolt is now Mend under a different integration, so
neither `.whitesource` nor `greenkeeper.json` is read by anything.

The Greenkeeper badge, where present, is worse than merely stale. Its image is
**byte-identical** for this repository and for one that does not exist, both rendering
"Greenkeeper - Move to Snyk", so it conveys nothing about this project. Verified by
fetching both and comparing.